### PR TITLE
revert renaming the main destination directory back to: "PyHardLinkBackup"

### DIFF
--- a/README.creole
+++ b/README.creole
@@ -57,20 +57,20 @@ This will create deduplication backups like this:
 # Download the file [[https://raw.githubusercontent.com/jedie/pyhardlinkbackup/master/boot_pyhardlinkbackup.cmd|boot_pyhardlinkbackup.cmd]]
 # call **boot_pyhardlinkbackup.cmd** as admin (Right-click and use **Run as administrator**)
 
-If everything works fine, you will get a venv here: {{{%ProgramFiles%\pyhardlinkbackup}}}
+If everything works fine, you will get a venv here: {{{%ProgramFiles%\PyHardLinkBackup}}}
 
 After the venv is created, call these scripts to finalize the setup:
 
-# {{{%ProgramFiles%\pyhardlinkbackup\phlb_edit_config.cmd}}} - create a config .ini file
-# {{{%ProgramFiles%\pyhardlinkbackup\phlb_migrate_database.cmd}}} - create database tables
+# {{{%ProgramFiles%\PyHardLinkBackup\phlb_edit_config.cmd}}} - create a config .ini file
+# {{{%ProgramFiles%\PyHardLinkBackup\phlb_migrate_database.cmd}}} - create database tables
 
 To upgrade pyhardlinkbackup, call:
 
-# {{{%ProgramFiles%\pyhardlinkbackup\phlb_upgrade_pyhardlinkbackup.cmd}}}
+# {{{%ProgramFiles%\PyHardLinkBackup\phlb_upgrade_pyhardlinkbackup.cmd}}}
 
 To start the Django webserver, call:
 
-# {{{%ProgramFiles%\pyhardlinkbackup\phlb_run_django_webserver.cmd}}}
+# {{{%ProgramFiles%\PyHardLinkBackup\phlb_run_django_webserver.cmd}}}
 
 
 === Linux
@@ -82,24 +82,24 @@ If everything works fine, you will get a venv here: {{{~\pyhardlinkbackup}}}
 
 After the venv is created, call these scripts to finalize the setup:
 
-* {{{~/pyhardlinkbackup/phlb_edit_config.sh}}} - create a config .ini file
-* {{{~/pyhardlinkbackup/phlb_migrate_database.sh}}} - create database tables
+* {{{~/PyHardLinkBackup/phlb_edit_config.sh}}} - create a config .ini file
+* {{{~/PyHardLinkBackup/phlb_migrate_database.sh}}} - create database tables
 
 To upgrade pyhardlinkbackup, call:
 
-* {{{~/pyhardlinkbackup/phlb_upgrade_pyhardlinkbackup.sh}}}
+* {{{~/PyHardLinkBackup/phlb_upgrade_pyhardlinkbackup.sh}}}
 
 To start the Django webserver, call:
 
-* {{{~/pyhardlinkbackup/phlb_run_django_webserver.sh}}}
+* {{{~/PyHardLinkBackup/phlb_run_django_webserver.sh}}}
 
 
 == Starting a backup run
 
 To start a backup run, use this helper script:
 
-* Windows batch: {{{%ProgramFiles%\pyhardlinkbackup\pyhardlinkbackup_this_directory.cmd}}}
-* Linux shell script: {{{~/pyhardlinkbackup/pyhardlinkbackup_this_directory.sh}}}
+* Windows batch: {{{%ProgramFiles%\PyHardLinkBackup\pyhardlinkbackup_this_directory.cmd}}}
+* Linux shell script: {{{~/PyHardLinkBackup/pyhardlinkbackup_this_directory.sh}}}
 
 Copy this file to a location that should be backed up and just call it to run a backup.
 
@@ -108,9 +108,9 @@ Copy this file to a location that should be backed up and just call it to run a 
 
 {{{
 $ cd pyhardlinkbackup/
-~/pyhardlinkbackup $ source bin/activate
+~/PyHardLinkBackup $ source bin/activate
 
-(pyhardlinkbackup) ~/pyhardlinkbackup $ phlb verify --fast ~/pyhardlinkbackups/documents/2016-01-07-102310
+(PyHardLinkBackup) ~/PyHardLinkBackup $ phlb verify --fast ~/PyHardLinkBackups/documents/2016-01-07-102310
 }}}
 With **--fast** the files' contents will not be checked.
 If not given: The hashes from the files' contents will be calculated and compared. Thus, every file must be completely read from filesystem, so it will take some time.
@@ -137,14 +137,14 @@ E.g. if the current working directoy is **/foo/bar/my_files/** then the search p
 * {{{/foo/bar/pyhardlinkbackup.ini}}}
 * {{{/foo/pyhardlinkbackup.ini}}}
 * {{{/pyhardlinkbackup.ini}}}
-* {{{~/pyhardlinkbackup.ini}}} //The user home directory under Windows/Linux//
+* {{{~/PyHardLinkBackup.ini}}} //The user home directory under Windows/Linux//
 
 
 === Create / edit default .ini
 
 You can just open the editor with the user directory .ini file with:
 {{{
-(pyhardlinkbackup) ~/pyhardlinkbackup $ phlb config
+(PyHardLinkBackup) ~/PyHardLinkBackup $ phlb config
 }}}
 
 The defaults are stored here: [[https://github.com/jedie/PyHardLinkBackup/blob/master/pyhardlinkbackup/phlb/config_defaults.ini|/phlb/config_defaults.ini]]
@@ -207,8 +207,8 @@ And then request 'localhost'
 Just start: {{{phlb_run_tests.cmd}}} / {{{phlb_run_tests.sh}}} or do this:
 {{{
 $ cd pyhardlinkbackup/
-~/pyhardlinkbackup $ source bin/activate
-(pyhardlinkbackup) ~/pyhardlinkbackup $ manage test
+~/PyHardLinkBackup $ source bin/activate
+(PyHardLinkBackup) ~/PyHardLinkBackup $ manage test
 }}}
 
 
@@ -216,8 +216,8 @@ $ cd pyhardlinkbackup/
 
 {{{
 $ cd pyhardlinkbackup/
-~/pyhardlinkbackup $ source bin/activate
-(pyhardlinkbackup) ~/pyhardlinkbackup $ phlb --help
+~/PyHardLinkBackup $ source bin/activate
+(PyHardLinkBackup) ~/PyHardLinkBackup $ phlb --help
 Usage: phlb [OPTIONS] COMMAND [ARGS]...
 
   pyhardlinkbackup
@@ -242,7 +242,7 @@ Commands:
 * add a backup manually
 
 **phlb add** does this:
-* scan the complete file tree under **BACKUP_PATH** (default: {{{~/pyhardlinkbackups}}})
+* scan the complete file tree under **BACKUP_PATH** (default: {{{~/PyHardLinkBackups}}})
 * recreate all hash files
 * add all files to database
 * deduplicate with hardlinks, if possible
@@ -259,7 +259,7 @@ Another scenario is e.g.:
 Do the following steps:
 
 * move the local files to a subdirectory below **BACKUP_PATH**
-* e.g.: {{{~/pyhardlinkbackups/pictures/2015-12-29-000015/}}}
+* e.g.: {{{~/PyHardLinkBackups/pictures/2015-12-29-000015/}}}
 * Note: the date format in the subdirectory name must match the **SUB_DIR_FORMATTER** in your config
 * run: **phlb add**
 
@@ -305,8 +305,8 @@ See also: https://github.com/restic/others#list-of-backup-software
 * 09.09.2016 - v0.10.1 - [[https://github.com/jedie/PyHardLinkBackup/compare/v0.10.0...v0.10.1|compare v0.10.0...v0.10.1]]
 ** Bugfix [[https://github.com/jedie/PyHardLinkBackup/issues/24|Catch scan dir errors #24]]
 * 26.04.2016 - v0.10.0 - [[https://github.com/jedie/PyHardLinkBackup/compare/v0.9.1...v0.10.0|compare v0.9.1...v0.10.0]]
-** move under Windows the install location from {{{%APPDATA%\pyhardlinkbackup}}} to {{{%ProgramFiles%\pyhardlinkbackup}}}
-** to 'migrate': Just delete {{{%APPDATA%\pyhardlinkbackup}}} and install via **boot_pyhardlinkbackup.cmd**
+** move under Windows the install location from {{{%APPDATA%\PyHardLinkBackup}}} to {{{%ProgramFiles%\PyHardLinkBackup}}}
+** to 'migrate': Just delete {{{%APPDATA%\PyHardLinkBackup}}} and install via **boot_pyhardlinkbackup.cmd**
 * 26.04.2016 - v0.9.1 - [[https://github.com/jedie/PyHardLinkBackup/compare/v0.9.0...v0.9.1|compare v0.9.0...v0.9.1]]
 ** run migrate database in boot process
 ** Add missing migrate scripts

--- a/README.creole
+++ b/README.creole
@@ -125,7 +125,7 @@ A verify run does:
 
 == Configuration
 
-phlb will use a configuration file named: **pyhardlinkbackup.ini**
+phlb will use a configuration file named: **PyHardLinkBackup.ini**
 
 Search order is:
 # current directory down to root
@@ -133,10 +133,10 @@ Search order is:
 
 E.g. if the current working directoy is **/foo/bar/my_files/** then the search path will be:
 
-* {{{/foo/bar/my_files/pyhardlinkbackup.ini}}}
-* {{{/foo/bar/pyhardlinkbackup.ini}}}
-* {{{/foo/pyhardlinkbackup.ini}}}
-* {{{/pyhardlinkbackup.ini}}}
+* {{{/foo/bar/my_files/PyHardLinkBackup.ini}}}
+* {{{/foo/bar/PyHardLinkBackup.ini}}}
+* {{{/foo/PyHardLinkBackup.ini}}}
+* {{{/PyHardLinkBackup.ini}}}
 * {{{~/PyHardLinkBackup.ini}}} //The user home directory under Windows/Linux//
 
 
@@ -153,7 +153,7 @@ The defaults are stored here: [[https://github.com/jedie/PyHardLinkBackup/blob/m
 === Excluding files/folders from backup:
 
 There are two ways to exclude files/folders from your backup.
-Use the follow settings in your {{{pyhardlinkbackup.ini}}}
+Use the follow settings in your {{{PyHardLinkBackup.ini}}}
 {{{
 # Directory names that will be recursively excluded from backups (comma separated list!)
 SKIP_DIRS= __pycache__, temp
@@ -286,8 +286,10 @@ See also: https://github.com/restic/others#list-of-backup-software
 
 == History
 
-* **dev** - [[https://github.com/jedie/PyHardLinkBackup/compare/v0.12.0...master|compare v0.12.0...master]]
+* **dev** - [[https://github.com/jedie/PyHardLinkBackup/compare/v0.12.1...master|compare v0.12.1...master]]
 ** TBC
+* 05.03.2020 - v0.12.1 - [[https://github.com/jedie/PyHardLinkBackup/compare/v0.12.0...v0.12.1|compare v0.12.0...v0.12.1]]
+** revert lowercase {{{PyHardLinkBackup}}} for environment destination and default backup directory.
 * 05.03.2020 - v0.12.0 - [[https://github.com/jedie/PyHardLinkBackup/compare/v0.11.0...v0.12.0|compare v0.11.0...v0.12.0]]
 ** Refactor backup process: Use https://github.com/jedie/IterFilesystem for less RAM usage and faster start on big source trees
 ** modernized project/sources:
@@ -351,7 +353,7 @@ See also: https://github.com/restic/others#list-of-backup-software
 * 22.01.2016 - v0.4.1 - [[https://github.com/jedie/PyHardLinkBackup/compare/v0.4.0...v0.4.1|compare v0.4.0...v0.4.1]]
 ** Skip files that can't be read/write. (and try to backup the remaining files)
 * 21.01.2016 - v0.4.0 - [[https://github.com/jedie/PyHardLinkBackup/compare/v0.3.1...v0.4.0|compare v0.3.1...v0.4.0]]
-** Search for //pyhardlinkbackup.ini// file in every parent directory from the current working dir
+** Search for //PyHardLinkBackup.ini// file in every parent directory from the current working dir
 ** increase default chunk size to 20MB
 ** save summary and log file for every backup run
 * 15.01.2016 - v0.3.1 - [[https://github.com/jedie/PyHardLinkBackup/compare/v0.3.0...v0.3.1|compare v0.3.0...v0.3.1]]

--- a/README.rst
+++ b/README.rst
@@ -151,7 +151,7 @@ Verifying an existing backup
 
     $ cd pyhardlinkbackup/
     ~/PyHardLinkBackup $ source bin/activate
-
+    
     (PyHardLinkBackup) ~/PyHardLinkBackup $ phlb verify --fast ~/PyHardLinkBackups/documents/2016-01-07-102310
 
 With **--fast** the files' contents will not be checked.
@@ -214,7 +214,7 @@ Use the follow settings in your ``PyHardLinkBackup.ini``
 
     # Directory names that will be recursively excluded from backups (comma separated list!)
     SKIP_DIRS= __pycache__, temp
-
+    
     # glob-style patterns to exclude files/folders from backups (used with Path.match(), Comma separated list!)
     SKIP_PATTERNS= *.pyc, *.tmp, *.cache
 
@@ -286,13 +286,13 @@ Using the CLI
     ~/PyHardLinkBackup $ source bin/activate
     (PyHardLinkBackup) ~/PyHardLinkBackup $ phlb --help
     Usage: phlb [OPTIONS] COMMAND [ARGS]...
-
+    
       pyhardlinkbackup
-
+    
     Options:
       --version  Show the version and exit.
       --help     Show this message and exit.
-
+    
     Commands:
       add     Scan all existing backup and add missing ones...
       backup  Start a Backup run
@@ -374,15 +374,15 @@ See also: `https://github.com/restic/others#list-of-backup-software <https://git
 History
 -------
 
-* **dev** - `compare v0.12.1...master <https://github.com/jedie/PyHardLinkBackup/compare/v0.12.1...master>`_
+* **dev** - `compare v0.12.1...master <https://github.com/jedie/PyHardLinkBackup/compare/v0.12.1...master>`_ 
 
     * TBC
 
-* 05.03.2020 - v0.12.1 - `compare v0.12.0...v0.12.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.12.0...v0.12.1>`_
+* 05.03.2020 - v0.12.1 - `compare v0.12.0...v0.12.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.12.0...v0.12.1>`_ 
 
     * revert lowercase ``PyHardLinkBackup`` for environment destination and default backup directory.
 
-* 05.03.2020 - v0.12.0 - `compare v0.11.0...v0.12.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.11.0...v0.12.0>`_
+* 05.03.2020 - v0.12.0 - `compare v0.11.0...v0.12.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.11.0...v0.12.0>`_ 
 
     * Refactor backup process: Use `https://github.com/jedie/IterFilesystem <https://github.com/jedie/IterFilesystem>`_ for less RAM usage and faster start on big source trees
 
@@ -404,45 +404,45 @@ History
 
     * **NOTE:** Windows support is not tested, yet! (Help wanted)
 
-* 03.03.2019 - v0.11.0 - `compare v0.10.1...v0.11.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.10.1...v0.11.0>`_
+* 03.03.2019 - v0.11.0 - `compare v0.10.1...v0.11.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.10.1...v0.11.0>`_ 
 
     * Update boot files
 
     * Use django v1.11.x
 
-* 09.09.2016 - v0.10.1 - `compare v0.10.0...v0.10.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.10.0...v0.10.1>`_
+* 09.09.2016 - v0.10.1 - `compare v0.10.0...v0.10.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.10.0...v0.10.1>`_ 
 
     * Bugfix `Catch scan dir errors #24 <https://github.com/jedie/PyHardLinkBackup/issues/24>`_
 
-* 26.04.2016 - v0.10.0 - `compare v0.9.1...v0.10.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.9.1...v0.10.0>`_
+* 26.04.2016 - v0.10.0 - `compare v0.9.1...v0.10.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.9.1...v0.10.0>`_ 
 
     * move under Windows the install location from ``%APPDATA%\PyHardLinkBackup`` to ``%ProgramFiles%\PyHardLinkBackup``
 
     * to 'migrate': Just delete ``%APPDATA%\PyHardLinkBackup`` and install via **boot_pyhardlinkbackup.cmd**
 
-* 26.04.2016 - v0.9.1 - `compare v0.9.0...v0.9.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.9.0...v0.9.1>`_
+* 26.04.2016 - v0.9.1 - `compare v0.9.0...v0.9.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.9.0...v0.9.1>`_ 
 
     * run migrate database in boot process
 
     * Add missing migrate scripts
 
-* 10.02.2016 - v0.9.0 - `compare v0.8.0...v0.9.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.8.0...v0.9.0>`_
+* 10.02.2016 - v0.9.0 - `compare v0.8.0...v0.9.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.8.0...v0.9.0>`_ 
 
     * Work-a-round for Windows MAX_PATH limit: Use ``\\?\`` path prefix internally.
 
     * move **Path2()** to external lib: `https://github.com/jedie/pathlib_revised <https://github.com/jedie/pathlib_revised>`_
 
-* 04.02.2016 - v0.8.0 - `compare v0.7.0...v0.8.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.7.0...v0.8.0>`_
+* 04.02.2016 - v0.8.0 - `compare v0.7.0...v0.8.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.7.0...v0.8.0>`_ 
 
     * New: add all missing backups to database: ``phlb add`` (s.above)
 
-* 03.02.2016 - v0.7.0 - `compare v0.6.4...v0.7.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.4...v0.7.0>`_
+* 03.02.2016 - v0.7.0 - `compare v0.6.4...v0.7.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.4...v0.7.0>`_ 
 
     * New: verify a existing backup
 
     * **IMPORTANT:** run database migration is needed!
 
-* 01.02.2016 - v0.6.4 - `compare v0.6.2...v0.6.4 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.3...v0.6.4>`_
+* 01.02.2016 - v0.6.4 - `compare v0.6.2...v0.6.4 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.3...v0.6.4>`_ 
 
     * Windows: Bugfix temp rename error, because of the Windows API limitation, see: `#13 <https://github.com/jedie/PyHardLinkBackup/issues/13#issuecomment-176241894>`_
 
@@ -450,25 +450,25 @@ History
 
     * Display local variables on low level errors
 
-* 29.01.2016 - v0.6.3 - `compare v0.6.2...v0.6.3 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.2...v0.6.3>`_
+* 29.01.2016 - v0.6.3 - `compare v0.6.2...v0.6.3 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.2...v0.6.3>`_ 
 
     * Less verbose and better information about SKIP_DIRS/SKIP_PATTERNS hits
 
-* 28.01.2016 - v0.6.2 - `compare v0.6.1...v0.6.2 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.1...v0.6.2>`_
+* 28.01.2016 - v0.6.2 - `compare v0.6.1...v0.6.2 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.1...v0.6.2>`_ 
 
     * Handle unexpected errors and continue backup with the next file
 
     * Better handle interrupt key during execution
 
-* 28.01.2016 - v0.6.1 - `compare v0.6.0...v0.6.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.0...v0.6.1>`_
+* 28.01.2016 - v0.6.1 - `compare v0.6.0...v0.6.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.0...v0.6.1>`_ 
 
     * Bugfix #13 by using a better temp rename routine
 
-* 28.01.2016 - v0.6.0 - `compare v0.5.1...v0.6.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.5.1...v0.6.0>`_
+* 28.01.2016 - v0.6.0 - `compare v0.5.1...v0.6.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.5.1...v0.6.0>`_ 
 
     * New: faster backup by compare mtime/size only if old backup files exists
 
-* 27.01.2016 - v0.5.1 - `compare v0.5.0...v0.5.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.5.0...v0.5.1>`_
+* 27.01.2016 - v0.5.1 - `compare v0.5.0...v0.5.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.5.0...v0.5.1>`_ 
 
     * **IMPORTANT:** run database migration is needed!
 
@@ -480,7 +480,7 @@ History
 
     * Add more information into summary file
 
-* 27.01.2016 - v0.5.0 - `compare v0.4.2...v0.5.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.2...v0.5.0>`_
+* 27.01.2016 - v0.5.0 - `compare v0.4.2...v0.5.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.2...v0.5.0>`_ 
 
     * refactory source tree scan. Split in two passed.
 
@@ -494,7 +494,7 @@ History
 
         * Display error message if backup name can be found (e.g.: backup a root folder)
 
-* 22.01.2016 - v0.4.2 - `compare v0.4.1...v0.4.2 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.1...v0.4.2>`_
+* 22.01.2016 - v0.4.2 - `compare v0.4.1...v0.4.2 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.1...v0.4.2>`_ 
 
     * work-a-round for junction under windows, see also: `https://www.python-forum.de/viewtopic.php?f=1&t=37725&p=290429#p290428 <https://www.python-forum.de/viewtopic.php?f=1&t=37725&p=290429#p290428>`_ (de)
 
@@ -502,11 +502,11 @@ History
 
     * print some more status information in between.
 
-* 22.01.2016 - v0.4.1 - `compare v0.4.0...v0.4.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.0...v0.4.1>`_
+* 22.01.2016 - v0.4.1 - `compare v0.4.0...v0.4.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.0...v0.4.1>`_ 
 
     * Skip files that can't be read/write. (and try to backup the remaining files)
 
-* 21.01.2016 - v0.4.0 - `compare v0.3.1...v0.4.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.3.1...v0.4.0>`_
+* 21.01.2016 - v0.4.0 - `compare v0.3.1...v0.4.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.3.1...v0.4.0>`_ 
 
     * Search for *PyHardLinkBackup.ini* file in every parent directory from the current working dir
 
@@ -514,29 +514,29 @@ History
 
     * save summary and log file for every backup run
 
-* 15.01.2016 - v0.3.1 - `compare v0.3.0...v0.3.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.3.0...v0.3.1>`_
+* 15.01.2016 - v0.3.1 - `compare v0.3.0...v0.3.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.3.0...v0.3.1>`_ 
 
     * fix unittest run under windows
 
-* 15.01.2016 - v0.3.0 - `compare v0.2.0...v0.3.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.2.0...v0.3.0>`_
+* 15.01.2016 - v0.3.0 - `compare v0.2.0...v0.3.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.2.0...v0.3.0>`_ 
 
     * **database migration needed**
 
     * Add 'no_link_source' to database (e.g. Skip source, if 1024 links created under windows)
 
-* 14.01.2016 - v0.2.0 - `compare v0.1.8...v0.2.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.1.8...v0.2.0>`_
+* 14.01.2016 - v0.2.0 - `compare v0.1.8...v0.2.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.1.8...v0.2.0>`_ 
 
     * good unittests coverage that covers the backup process
 
-* 08.01.2016 - v0.1.8 - `compare v0.1.0alpha0...v0.1.8 <https://github.com/jedie/PyHardLinkBackup/compare/v0.1.0alpha0...v0.1.8>`_
+* 08.01.2016 - v0.1.8 - `compare v0.1.0alpha0...v0.1.8 <https://github.com/jedie/PyHardLinkBackup/compare/v0.1.0alpha0...v0.1.8>`_ 
 
     * install and runable under Windows
 
-* 06.01.2016 - v0.1.0alpha0 - `d42a5c5 <https://github.com/jedie/PyHardLinkBackup/commit/d42a5c59c0dcdf8d2f8bb2a3a3dc2c51862fed17>`_
+* 06.01.2016 - v0.1.0alpha0 - `d42a5c5 <https://github.com/jedie/PyHardLinkBackup/commit/d42a5c59c0dcdf8d2f8bb2a3a3dc2c51862fed17>`_ 
 
     * first Release on PyPi
 
-* 29.12.2015 - `commit 2ce43 <https://github.com/jedie/PyHardLinkBackup/commit/2ce43d326fafbde5a3526194cf957f00efe0f198>`_
+* 29.12.2015 - `commit 2ce43 <https://github.com/jedie/PyHardLinkBackup/commit/2ce43d326fafbde5a3526194cf957f00efe0f198>`_ 
 
     * commit 'Proof of concept'
 
@@ -562,4 +562,4 @@ Donating
 
 ------------
 
-``Note: this file is generated from README.creole 2020-03-05 22:30:44 with "python-creole"``
+``Note: this file is generated from README.creole 2020-03-05 22:34:42 with "python-creole"``

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ This will create deduplication backups like this:
 
 ::
 
-    ~/pyhardlinkbackups
+    ~/PyHardLinkBackups
       └── documents
           ├── 2016-01-07-085247
           │   ├── phlb_config.ini
@@ -92,21 +92,21 @@ Windows
 
 #. call **boot_pyhardlinkbackup.cmd** as admin (Right-click and use **Run as administrator**)
 
-If everything works fine, you will get a venv here: ``%ProgramFiles%\pyhardlinkbackup``
+If everything works fine, you will get a venv here: ``%ProgramFiles%\PyHardLinkBackup``
 
 After the venv is created, call these scripts to finalize the setup:
 
-#. ``%ProgramFiles%\pyhardlinkbackup\phlb_edit_config.cmd`` - create a config .ini file
+#. ``%ProgramFiles%\PyHardLinkBackup\phlb_edit_config.cmd`` - create a config .ini file
 
-#. ``%ProgramFiles%\pyhardlinkbackup\phlb_migrate_database.cmd`` - create database tables
+#. ``%ProgramFiles%\PyHardLinkBackup\phlb_migrate_database.cmd`` - create database tables
 
 To upgrade pyhardlinkbackup, call:
 
-#. ``%ProgramFiles%\pyhardlinkbackup\phlb_upgrade_pyhardlinkbackup.cmd``
+#. ``%ProgramFiles%\PyHardLinkBackup\phlb_upgrade_pyhardlinkbackup.cmd``
 
 To start the Django webserver, call:
 
-#. ``%ProgramFiles%\pyhardlinkbackup\phlb_run_django_webserver.cmd``
+#. ``%ProgramFiles%\PyHardLinkBackup\phlb_run_django_webserver.cmd``
 
 Linux
 =====
@@ -119,17 +119,17 @@ If everything works fine, you will get a venv here: ``~\pyhardlinkbackup``
 
 After the venv is created, call these scripts to finalize the setup:
 
-* ``~/pyhardlinkbackup/phlb_edit_config.sh`` - create a config .ini file
+* ``~/PyHardLinkBackup/phlb_edit_config.sh`` - create a config .ini file
 
-* ``~/pyhardlinkbackup/phlb_migrate_database.sh`` - create database tables
+* ``~/PyHardLinkBackup/phlb_migrate_database.sh`` - create database tables
 
 To upgrade pyhardlinkbackup, call:
 
-* ``~/pyhardlinkbackup/phlb_upgrade_pyhardlinkbackup.sh``
+* ``~/PyHardLinkBackup/phlb_upgrade_pyhardlinkbackup.sh``
 
 To start the Django webserver, call:
 
-* ``~/pyhardlinkbackup/phlb_run_django_webserver.sh``
+* ``~/PyHardLinkBackup/phlb_run_django_webserver.sh``
 
 ---------------------
 Starting a backup run
@@ -137,9 +137,9 @@ Starting a backup run
 
 To start a backup run, use this helper script:
 
-* Windows batch: ``%ProgramFiles%\pyhardlinkbackup\pyhardlinkbackup_this_directory.cmd``
+* Windows batch: ``%ProgramFiles%\PyHardLinkBackup\pyhardlinkbackup_this_directory.cmd``
 
-* Linux shell script: ``~/pyhardlinkbackup/pyhardlinkbackup_this_directory.sh``
+* Linux shell script: ``~/PyHardLinkBackup/pyhardlinkbackup_this_directory.sh``
 
 Copy this file to a location that should be backed up and just call it to run a backup.
 
@@ -150,9 +150,9 @@ Verifying an existing backup
 ::
 
     $ cd pyhardlinkbackup/
-    ~/pyhardlinkbackup $ source bin/activate
-    
-    (pyhardlinkbackup) ~/pyhardlinkbackup $ phlb verify --fast ~/pyhardlinkbackups/documents/2016-01-07-102310
+    ~/PyHardLinkBackup $ source bin/activate
+
+    (PyHardLinkBackup) ~/PyHardLinkBackup $ phlb verify --fast ~/PyHardLinkBackups/documents/2016-01-07-102310
 
 With **--fast** the files' contents will not be checked.
 If not given: The hashes from the files' contents will be calculated and compared. Thus, every file must be completely read from filesystem, so it will take some time.
@@ -191,7 +191,7 @@ E.g. if the current working directoy is **/foo/bar/my_files/** then the search p
 
 * ``/pyhardlinkbackup.ini``
 
-* ``~/pyhardlinkbackup.ini`` *The user home directory under Windows/Linux*
+* ``~/PyHardLinkBackup.ini`` *The user home directory under Windows/Linux*
 
 Create / edit default .ini
 ==========================
@@ -200,7 +200,7 @@ You can just open the editor with the user directory .ini file with:
 
 ::
 
-    (pyhardlinkbackup) ~/pyhardlinkbackup $ phlb config
+    (PyHardLinkBackup) ~/PyHardLinkBackup $ phlb config
 
 The defaults are stored here: `/phlb/config_defaults.ini <https://github.com/jedie/PyHardLinkBackup/blob/master/pyhardlinkbackup/phlb/config_defaults.ini>`_
 
@@ -214,7 +214,7 @@ Use the follow settings in your ``pyhardlinkbackup.ini``
 
     # Directory names that will be recursively excluded from backups (comma separated list!)
     SKIP_DIRS= __pycache__, temp
-    
+
     # glob-style patterns to exclude files/folders from backups (used with Path.match(), Comma separated list!)
     SKIP_PATTERNS= *.pyc, *.tmp, *.cache
 
@@ -273,8 +273,8 @@ Just start: ``phlb_run_tests.cmd`` / ``phlb_run_tests.sh`` or do this:
 ::
 
     $ cd pyhardlinkbackup/
-    ~/pyhardlinkbackup $ source bin/activate
-    (pyhardlinkbackup) ~/pyhardlinkbackup $ manage test
+    ~/PyHardLinkBackup $ source bin/activate
+    (PyHardLinkBackup) ~/PyHardLinkBackup $ manage test
 
 -------------
 Using the CLI
@@ -283,16 +283,16 @@ Using the CLI
 ::
 
     $ cd pyhardlinkbackup/
-    ~/pyhardlinkbackup $ source bin/activate
-    (pyhardlinkbackup) ~/pyhardlinkbackup $ phlb --help
+    ~/PyHardLinkBackup $ source bin/activate
+    (PyHardLinkBackup) ~/PyHardLinkBackup $ phlb --help
     Usage: phlb [OPTIONS] COMMAND [ARGS]...
-    
+
       pyhardlinkbackup
-    
+
     Options:
       --version  Show the version and exit.
       --help     Show this message and exit.
-    
+
     Commands:
       add     Scan all existing backup and add missing ones...
       backup  Start a Backup run
@@ -312,7 +312,7 @@ Add missing backups to the database
 
 **phlb add** does this:
 
-* scan the complete file tree under **BACKUP_PATH** (default: ``~/pyhardlinkbackups``)
+* scan the complete file tree under **BACKUP_PATH** (default: ``~/PyHardLinkBackups``)
 
 * recreate all hash files
 
@@ -338,7 +338,7 @@ Do the following steps:
 
 * move the local files to a subdirectory below **BACKUP_PATH**
 
-* e.g.: ``~/pyhardlinkbackups/pictures/2015-12-29-000015/``
+* e.g.: ``~/PyHardLinkBackups/pictures/2015-12-29-000015/``
 
 * Note: the date format in the subdirectory name must match the **SUB_DIR_FORMATTER** in your config
 
@@ -374,11 +374,11 @@ See also: `https://github.com/restic/others#list-of-backup-software <https://git
 History
 -------
 
-* **dev** - `compare v0.12.0...master <https://github.com/jedie/PyHardLinkBackup/compare/v0.12.0...master>`_ 
+* **dev** - `compare v0.12.0...master <https://github.com/jedie/PyHardLinkBackup/compare/v0.12.0...master>`_
 
     * TBC
 
-* 05.03.2020 - v0.12.0 - `compare v0.11.0...v0.12.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.11.0...v0.12.0>`_ 
+* 05.03.2020 - v0.12.0 - `compare v0.11.0...v0.12.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.11.0...v0.12.0>`_
 
     * Refactor backup process: Use `https://github.com/jedie/IterFilesystem <https://github.com/jedie/IterFilesystem>`_ for less RAM usage and faster start on big source trees
 
@@ -400,45 +400,45 @@ History
 
     * **NOTE:** Windows support is not tested, yet! (Help wanted)
 
-* 03.03.2019 - v0.11.0 - `compare v0.10.1...v0.11.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.10.1...v0.11.0>`_ 
+* 03.03.2019 - v0.11.0 - `compare v0.10.1...v0.11.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.10.1...v0.11.0>`_
 
     * Update boot files
 
     * Use django v1.11.x
 
-* 09.09.2016 - v0.10.1 - `compare v0.10.0...v0.10.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.10.0...v0.10.1>`_ 
+* 09.09.2016 - v0.10.1 - `compare v0.10.0...v0.10.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.10.0...v0.10.1>`_
 
     * Bugfix `Catch scan dir errors #24 <https://github.com/jedie/PyHardLinkBackup/issues/24>`_
 
-* 26.04.2016 - v0.10.0 - `compare v0.9.1...v0.10.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.9.1...v0.10.0>`_ 
+* 26.04.2016 - v0.10.0 - `compare v0.9.1...v0.10.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.9.1...v0.10.0>`_
 
-    * move under Windows the install location from ``%APPDATA%\pyhardlinkbackup`` to ``%ProgramFiles%\pyhardlinkbackup``
+    * move under Windows the install location from ``%APPDATA%\PyHardLinkBackup`` to ``%ProgramFiles%\PyHardLinkBackup``
 
-    * to 'migrate': Just delete ``%APPDATA%\pyhardlinkbackup`` and install via **boot_pyhardlinkbackup.cmd**
+    * to 'migrate': Just delete ``%APPDATA%\PyHardLinkBackup`` and install via **boot_pyhardlinkbackup.cmd**
 
-* 26.04.2016 - v0.9.1 - `compare v0.9.0...v0.9.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.9.0...v0.9.1>`_ 
+* 26.04.2016 - v0.9.1 - `compare v0.9.0...v0.9.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.9.0...v0.9.1>`_
 
     * run migrate database in boot process
 
     * Add missing migrate scripts
 
-* 10.02.2016 - v0.9.0 - `compare v0.8.0...v0.9.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.8.0...v0.9.0>`_ 
+* 10.02.2016 - v0.9.0 - `compare v0.8.0...v0.9.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.8.0...v0.9.0>`_
 
     * Work-a-round for Windows MAX_PATH limit: Use ``\\?\`` path prefix internally.
 
     * move **Path2()** to external lib: `https://github.com/jedie/pathlib_revised <https://github.com/jedie/pathlib_revised>`_
 
-* 04.02.2016 - v0.8.0 - `compare v0.7.0...v0.8.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.7.0...v0.8.0>`_ 
+* 04.02.2016 - v0.8.0 - `compare v0.7.0...v0.8.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.7.0...v0.8.0>`_
 
     * New: add all missing backups to database: ``phlb add`` (s.above)
 
-* 03.02.2016 - v0.7.0 - `compare v0.6.4...v0.7.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.4...v0.7.0>`_ 
+* 03.02.2016 - v0.7.0 - `compare v0.6.4...v0.7.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.4...v0.7.0>`_
 
     * New: verify a existing backup
 
     * **IMPORTANT:** run database migration is needed!
 
-* 01.02.2016 - v0.6.4 - `compare v0.6.2...v0.6.4 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.3...v0.6.4>`_ 
+* 01.02.2016 - v0.6.4 - `compare v0.6.2...v0.6.4 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.3...v0.6.4>`_
 
     * Windows: Bugfix temp rename error, because of the Windows API limitation, see: `#13 <https://github.com/jedie/PyHardLinkBackup/issues/13#issuecomment-176241894>`_
 
@@ -446,25 +446,25 @@ History
 
     * Display local variables on low level errors
 
-* 29.01.2016 - v0.6.3 - `compare v0.6.2...v0.6.3 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.2...v0.6.3>`_ 
+* 29.01.2016 - v0.6.3 - `compare v0.6.2...v0.6.3 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.2...v0.6.3>`_
 
     * Less verbose and better information about SKIP_DIRS/SKIP_PATTERNS hits
 
-* 28.01.2016 - v0.6.2 - `compare v0.6.1...v0.6.2 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.1...v0.6.2>`_ 
+* 28.01.2016 - v0.6.2 - `compare v0.6.1...v0.6.2 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.1...v0.6.2>`_
 
     * Handle unexpected errors and continue backup with the next file
 
     * Better handle interrupt key during execution
 
-* 28.01.2016 - v0.6.1 - `compare v0.6.0...v0.6.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.0...v0.6.1>`_ 
+* 28.01.2016 - v0.6.1 - `compare v0.6.0...v0.6.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.6.0...v0.6.1>`_
 
     * Bugfix #13 by using a better temp rename routine
 
-* 28.01.2016 - v0.6.0 - `compare v0.5.1...v0.6.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.5.1...v0.6.0>`_ 
+* 28.01.2016 - v0.6.0 - `compare v0.5.1...v0.6.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.5.1...v0.6.0>`_
 
     * New: faster backup by compare mtime/size only if old backup files exists
 
-* 27.01.2016 - v0.5.1 - `compare v0.5.0...v0.5.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.5.0...v0.5.1>`_ 
+* 27.01.2016 - v0.5.1 - `compare v0.5.0...v0.5.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.5.0...v0.5.1>`_
 
     * **IMPORTANT:** run database migration is needed!
 
@@ -476,7 +476,7 @@ History
 
     * Add more information into summary file
 
-* 27.01.2016 - v0.5.0 - `compare v0.4.2...v0.5.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.2...v0.5.0>`_ 
+* 27.01.2016 - v0.5.0 - `compare v0.4.2...v0.5.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.2...v0.5.0>`_
 
     * refactory source tree scan. Split in two passed.
 
@@ -490,7 +490,7 @@ History
 
         * Display error message if backup name can be found (e.g.: backup a root folder)
 
-* 22.01.2016 - v0.4.2 - `compare v0.4.1...v0.4.2 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.1...v0.4.2>`_ 
+* 22.01.2016 - v0.4.2 - `compare v0.4.1...v0.4.2 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.1...v0.4.2>`_
 
     * work-a-round for junction under windows, see also: `https://www.python-forum.de/viewtopic.php?f=1&t=37725&p=290429#p290428 <https://www.python-forum.de/viewtopic.php?f=1&t=37725&p=290429#p290428>`_ (de)
 
@@ -498,11 +498,11 @@ History
 
     * print some more status information in between.
 
-* 22.01.2016 - v0.4.1 - `compare v0.4.0...v0.4.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.0...v0.4.1>`_ 
+* 22.01.2016 - v0.4.1 - `compare v0.4.0...v0.4.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.4.0...v0.4.1>`_
 
     * Skip files that can't be read/write. (and try to backup the remaining files)
 
-* 21.01.2016 - v0.4.0 - `compare v0.3.1...v0.4.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.3.1...v0.4.0>`_ 
+* 21.01.2016 - v0.4.0 - `compare v0.3.1...v0.4.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.3.1...v0.4.0>`_
 
     * Search for *pyhardlinkbackup.ini* file in every parent directory from the current working dir
 
@@ -510,29 +510,29 @@ History
 
     * save summary and log file for every backup run
 
-* 15.01.2016 - v0.3.1 - `compare v0.3.0...v0.3.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.3.0...v0.3.1>`_ 
+* 15.01.2016 - v0.3.1 - `compare v0.3.0...v0.3.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.3.0...v0.3.1>`_
 
     * fix unittest run under windows
 
-* 15.01.2016 - v0.3.0 - `compare v0.2.0...v0.3.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.2.0...v0.3.0>`_ 
+* 15.01.2016 - v0.3.0 - `compare v0.2.0...v0.3.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.2.0...v0.3.0>`_
 
     * **database migration needed**
 
     * Add 'no_link_source' to database (e.g. Skip source, if 1024 links created under windows)
 
-* 14.01.2016 - v0.2.0 - `compare v0.1.8...v0.2.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.1.8...v0.2.0>`_ 
+* 14.01.2016 - v0.2.0 - `compare v0.1.8...v0.2.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.1.8...v0.2.0>`_
 
     * good unittests coverage that covers the backup process
 
-* 08.01.2016 - v0.1.8 - `compare v0.1.0alpha0...v0.1.8 <https://github.com/jedie/PyHardLinkBackup/compare/v0.1.0alpha0...v0.1.8>`_ 
+* 08.01.2016 - v0.1.8 - `compare v0.1.0alpha0...v0.1.8 <https://github.com/jedie/PyHardLinkBackup/compare/v0.1.0alpha0...v0.1.8>`_
 
     * install and runable under Windows
 
-* 06.01.2016 - v0.1.0alpha0 - `d42a5c5 <https://github.com/jedie/PyHardLinkBackup/commit/d42a5c59c0dcdf8d2f8bb2a3a3dc2c51862fed17>`_ 
+* 06.01.2016 - v0.1.0alpha0 - `d42a5c5 <https://github.com/jedie/PyHardLinkBackup/commit/d42a5c59c0dcdf8d2f8bb2a3a3dc2c51862fed17>`_
 
     * first Release on PyPi
 
-* 29.12.2015 - `commit 2ce43 <https://github.com/jedie/PyHardLinkBackup/commit/2ce43d326fafbde5a3526194cf957f00efe0f198>`_ 
+* 29.12.2015 - `commit 2ce43 <https://github.com/jedie/PyHardLinkBackup/commit/2ce43d326fafbde5a3526194cf957f00efe0f198>`_
 
     * commit 'Proof of concept'
 

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ This will create deduplication backups like this:
 
 ::
 
-    ~/PyHardLinkBackups
+    ~/pyhardlinkbackups
       └── documents
           ├── 2016-01-07-085247
           │   ├── phlb_config.ini
@@ -173,7 +173,7 @@ A verify run does:
 Configuration
 -------------
 
-phlb will use a configuration file named: **pyhardlinkbackup.ini**
+phlb will use a configuration file named: **PyHardLinkBackup.ini**
 
 Search order is:
 
@@ -183,13 +183,13 @@ Search order is:
 
 E.g. if the current working directoy is **/foo/bar/my_files/** then the search path will be:
 
-* ``/foo/bar/my_files/pyhardlinkbackup.ini``
+* ``/foo/bar/my_files/PyHardLinkBackup.ini``
 
-* ``/foo/bar/pyhardlinkbackup.ini``
+* ``/foo/bar/PyHardLinkBackup.ini``
 
-* ``/foo/pyhardlinkbackup.ini``
+* ``/foo/PyHardLinkBackup.ini``
 
-* ``/pyhardlinkbackup.ini``
+* ``/PyHardLinkBackup.ini``
 
 * ``~/PyHardLinkBackup.ini`` *The user home directory under Windows/Linux*
 
@@ -208,7 +208,7 @@ Excluding files/folders from backup:
 ====================================
 
 There are two ways to exclude files/folders from your backup.
-Use the follow settings in your ``pyhardlinkbackup.ini``
+Use the follow settings in your ``PyHardLinkBackup.ini``
 
 ::
 
@@ -374,9 +374,13 @@ See also: `https://github.com/restic/others#list-of-backup-software <https://git
 History
 -------
 
-* **dev** - `compare v0.12.0...master <https://github.com/jedie/PyHardLinkBackup/compare/v0.12.0...master>`_
+* **dev** - `compare v0.12.1...master <https://github.com/jedie/PyHardLinkBackup/compare/v0.12.1...master>`_
 
     * TBC
+
+* 05.03.2020 - v0.12.1 - `compare v0.12.0...v0.12.1 <https://github.com/jedie/PyHardLinkBackup/compare/v0.12.0...v0.12.1>`_
+
+    * revert lowercase ``PyHardLinkBackup`` for environment destination and default backup directory.
 
 * 05.03.2020 - v0.12.0 - `compare v0.11.0...v0.12.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.11.0...v0.12.0>`_
 
@@ -504,7 +508,7 @@ History
 
 * 21.01.2016 - v0.4.0 - `compare v0.3.1...v0.4.0 <https://github.com/jedie/PyHardLinkBackup/compare/v0.3.1...v0.4.0>`_
 
-    * Search for *pyhardlinkbackup.ini* file in every parent directory from the current working dir
+    * Search for *PyHardLinkBackup.ini* file in every parent directory from the current working dir
 
     * increase default chunk size to 20MB
 
@@ -558,4 +562,4 @@ Donating
 
 ------------
 
-``Note: this file is generated from README.creole 2020-03-05 21:55:43 with "python-creole"``
+``Note: this file is generated from README.creole 2020-03-05 22:30:44 with "python-creole"``

--- a/boot_pyhardlinkbackup.cmd
+++ b/boot_pyhardlinkbackup.cmd
@@ -46,7 +46,7 @@ if errorlevel 1 (
     exit /b
 )
 
-set BASE_PATH=%ProgramFiles%\pyhardlinkbackup
+set BASE_PATH=%ProgramFiles%\PyHardLinkBackup
 echo on
 mkdir "%BASE_PATH%"
 @echo off

--- a/boot_pyhardlinkbackup.sh
+++ b/boot_pyhardlinkbackup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DESTINATION=~/PyHardLinkBackup-dev
+DESTINATION=~/PyHardLinkBackup
 
 (
     set -e

--- a/pyhardlinkbackup/__init__.py
+++ b/pyhardlinkbackup/__init__.py
@@ -1,5 +1,5 @@
 import os
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pyhardlinkbackup.django_project.settings")

--- a/pyhardlinkbackup/helper_cmd/PyHardLinkBackup_this_directory.cmd
+++ b/pyhardlinkbackup/helper_cmd/PyHardLinkBackup_this_directory.cmd
@@ -1,7 +1,7 @@
 @echo off
 title %~0
 
-set BASE_PATH=%ProgramFiles%\pyhardlinkbackup
+set BASE_PATH=%ProgramFiles%\PyHardLinkBackup
 call:test_exist "%BASE_PATH%" "venv not found here:"
 cd /d "%BASE_PATH%"
 

--- a/pyhardlinkbackup/helper_cmd/cmd_shell.cmd
+++ b/pyhardlinkbackup/helper_cmd/cmd_shell.cmd
@@ -1,7 +1,7 @@
 @echo off
 title %~0
 
-set BASE_PATH=%ProgramFiles%\pyhardlinkbackup
+set BASE_PATH=%ProgramFiles%\PyHardLinkBackup
 call:test_exist "%BASE_PATH%" "venv not found here:"
 cd /d "%BASE_PATH%"
 

--- a/pyhardlinkbackup/helper_cmd/phlb_edit_config.cmd
+++ b/pyhardlinkbackup/helper_cmd/phlb_edit_config.cmd
@@ -1,7 +1,7 @@
 @echo off
 title %~0
 
-set BASE_PATH=%ProgramFiles%\pyhardlinkbackup
+set BASE_PATH=%ProgramFiles%\PyHardLinkBackup
 call:test_exist "%BASE_PATH%" "venv not found here:"
 cd /d "%BASE_PATH%"
 

--- a/pyhardlinkbackup/helper_cmd/phlb_migrate_database.cmd
+++ b/pyhardlinkbackup/helper_cmd/phlb_migrate_database.cmd
@@ -1,7 +1,7 @@
 @echo off
 title %~0
 
-set BASE_PATH=%ProgramFiles%\pyhardlinkbackup
+set BASE_PATH=%ProgramFiles%\PyHardLinkBackup
 call:test_exist "%BASE_PATH%" "venv not found here:"
 cd /d "%BASE_PATH%"
 

--- a/pyhardlinkbackup/helper_cmd/phlb_run_django_webserver.cmd
+++ b/pyhardlinkbackup/helper_cmd/phlb_run_django_webserver.cmd
@@ -1,7 +1,7 @@
 @echo off
 title %~0
 
-set BASE_PATH=%ProgramFiles%\pyhardlinkbackup
+set BASE_PATH=%ProgramFiles%\PyHardLinkBackup
 call:test_exist "%BASE_PATH%" "venv not found here:"
 cd /d "%BASE_PATH%"
 

--- a/pyhardlinkbackup/helper_cmd/phlb_run_tests.cmd
+++ b/pyhardlinkbackup/helper_cmd/phlb_run_tests.cmd
@@ -1,7 +1,7 @@
 @echo off
 title %~0
 
-set BASE_PATH=%ProgramFiles%\pyhardlinkbackup
+set BASE_PATH=%ProgramFiles%\PyHardLinkBackup
 call:test_exist "%BASE_PATH%" "venv not found here:"
 cd /d "%BASE_PATH%"
 

--- a/pyhardlinkbackup/helper_cmd/phlb_upgrade_PyHardLinkBackup.cmd
+++ b/pyhardlinkbackup/helper_cmd/phlb_upgrade_PyHardLinkBackup.cmd
@@ -1,7 +1,7 @@
 @echo off
 title %~0
 
-set BASE_PATH=%ProgramFiles%\pyhardlinkbackup
+set BASE_PATH=%ProgramFiles%\PyHardLinkBackup
 call:test_exist "%BASE_PATH%" "venv not found here:"
 cd /d "%BASE_PATH%"
 

--- a/pyhardlinkbackup/helper_sh/PyHardLinkBackup_this_directory.sh
+++ b/pyhardlinkbackup/helper_sh/PyHardLinkBackup_this_directory.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ENV_PATH=~/pyhardlinkbackup
+ENV_PATH=~/PyHardLinkBackup
 CURRENT_DIR=$(pwd)
 
 set -e

--- a/pyhardlinkbackup/helper_sh/phlb_edit_config.sh
+++ b/pyhardlinkbackup/helper_sh/phlb_edit_config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ENV_PATH=~/pyhardlinkbackup
+ENV_PATH=~/PyHardLinkBackup
 CURRENT_DIR=$(pwd)
 
 set -e

--- a/pyhardlinkbackup/helper_sh/phlb_migrate_database.sh
+++ b/pyhardlinkbackup/helper_sh/phlb_migrate_database.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ENV_PATH=~/pyhardlinkbackup
+ENV_PATH=~/PyHardLinkBackup
 CURRENT_DIR=$(pwd)
 
 set -e

--- a/pyhardlinkbackup/helper_sh/phlb_run_django_webserver.sh
+++ b/pyhardlinkbackup/helper_sh/phlb_run_django_webserver.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ENV_PATH=~/pyhardlinkbackup
+ENV_PATH=~/PyHardLinkBackup
 CURRENT_DIR=$(pwd)
 
 set -e

--- a/pyhardlinkbackup/helper_sh/phlb_run_tests.sh
+++ b/pyhardlinkbackup/helper_sh/phlb_run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ENV_PATH=~/pyhardlinkbackup
+ENV_PATH=~/PyHardLinkBackup
 CURRENT_DIR=$(pwd)
 
 set -e

--- a/pyhardlinkbackup/helper_sh/phlb_upgrade_PyHardLinkBackup.sh
+++ b/pyhardlinkbackup/helper_sh/phlb_upgrade_PyHardLinkBackup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ENV_PATH=~/pyhardlinkbackup
+ENV_PATH=~/PyHardLinkBackup
 CURRENT_DIR=$(pwd)
 
 set -e

--- a/pyhardlinkbackup/phlb/cli.py
+++ b/pyhardlinkbackup/phlb/cli.py
@@ -26,9 +26,9 @@ PHLB_BASE_DIR = os.path.abspath(os.path.dirname(pyhardlinkbackup.__file__))
 @click.version_option(version=pyhardlinkbackup.__version__)
 @click.pass_context
 def cli(ctx):
-    """pyhardlinkbackup"""
+    """PyHardLinkBackup"""
     click.secho(
-        f"\npyhardlinkbackup v{pyhardlinkbackup.__version__}\n",
+        f"\nPyHardLinkBackup v{pyhardlinkbackup.__version__}\n",
         bg="blue",
         fg="white",
         bold=True)

--- a/pyhardlinkbackup/phlb/config.py
+++ b/pyhardlinkbackup/phlb/config.py
@@ -15,7 +15,7 @@ from pathlib_revised import Path2
 
 log = logging.getLogger(f"phlb.{__name__}")
 
-CONFIG_FILENAME = "pyhardlinkbackup.ini"
+CONFIG_FILENAME = "PyHardLinkBackup.ini"
 DEAFULT_CONFIG_FILENAME = "config_defaults.ini"
 
 

--- a/pyhardlinkbackup/phlb/config_defaults.ini
+++ b/pyhardlinkbackup/phlb/config_defaults.ini
@@ -1,11 +1,11 @@
 #
-# Configuration for pyhardlinkbackup:
+# Configuration for PyHardLinkBackup:
 # https://github.com/jedie/PyHardLinkBackup
 #
 
 [common]
 # Path for the SQLite database file
-DATABASE_NAME= ~/pyhardlinkbackups.sqlite3
+DATABASE_NAME= ~/PyHardLinkBackups.sqlite3
 # NOTE: Please run 'migrate database' if you change the filepath!
 
 # Disable the auth mechanism in django admin panel and auto login everybody
@@ -17,7 +17,7 @@ LANGUAGE_CODE= en-us
 
 [backup]
 # Root directory for all backups
-BACKUP_PATH= ~/pyhardlinkbackups
+BACKUP_PATH= ~/PyHardLinkBackups
 
 # datetime.strftime() formatter to create the sub directory.
 SUB_DIR_FORMATTER= %Y-%m-%d-%H%M%S

--- a/pyhardlinkbackup/phlb/verify.py
+++ b/pyhardlinkbackup/phlb/verify.py
@@ -112,8 +112,8 @@ def verify_backup(backup_path, fast):
 
 if __name__ == "__main__":
     backup_path = os.path.expanduser(
-        # "~/pyhardlinkbackups/pyhardlinkbackup"
-        "~/pyhardlinkbackups/pyhardlinkbackup/2016-01-29-160915"
+        # "~/PyHardLinkBackups/pyhardlinkbackup"
+        "~/PyHardLinkBackups/pyhardlinkbackup/2016-01-29-160915"
     )
     verify_backup(
         backup_path,

--- a/pyhardlinkbackup/tests/base.py
+++ b/pyhardlinkbackup/tests/base.py
@@ -82,7 +82,7 @@ class BaseTestCase(BaseTempTestCase, TestCase):
             f.write('Truncate log file in setUp()\n')
 
         self.backup_path = os.path.join(self.temp_root_path, "pyhardlinkbackups")
-        self.ini_path = os.path.join(self.temp_root_path, "pyhardlinkbackup.ini")
+        self.ini_path = os.path.join(self.temp_root_path, "PyHardLinkBackup.ini")
 
         # set_phlb_logger(logging.DEBUG)
 

--- a/pyhardlinkbackup/tests/test_cli.py
+++ b/pyhardlinkbackup/tests/test_cli.py
@@ -11,8 +11,8 @@ class TestCli(unittest.TestCase):
     def test_help(self):
         runner = CliRunner()
         result = runner.invoke(cli, ["--help"])
-        # print(result.output)
-        self.assertIn("pyhardlinkbackup", result.output)
+        print(result.output)
+        self.assertIn("PyHardLinkBackup", result.output)
         self.assertIn("backup", result.output)
         self.assertIn("config", result.output)
         self.assertIn("helper", result.output)

--- a/pyhardlinkbackup/tests/test_config.py
+++ b/pyhardlinkbackup/tests/test_config.py
@@ -8,7 +8,7 @@ from django_tools.unittest_utils.assertments import assert_pformat_equal
 from pyhardlinkbackup.phlb.config import phlb_config
 from pyhardlinkbackup.tests.base import BaseTestCase
 
-USER_INI_PATH = os.path.join(os.path.expanduser("~"), "pyhardlinkbackup.ini")
+USER_INI_PATH = os.path.join(os.path.expanduser("~"), "PyHardLinkBackup.ini")
 
 
 class TestConfig(BaseTestCase):
@@ -21,7 +21,7 @@ class TestConfig(BaseTestCase):
         result = self.invoke_cli("config", "--debug")
         self.assertIn("pyhardlinkbackup", result.output)
 
-        # check if unittest temp pyhardlinkbackup.ini is used:
+        # check if unittest temp PyHardLinkBackup.ini is used:
         self.assertIn(self.ini_path, result.output)
 
         # check the defaults:
@@ -58,7 +58,7 @@ class TestConfig(BaseTestCase):
         """
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("pyhardlinkbackup.ini", "w") as ini:
+            with open("PyHardLinkBackup.ini", "w") as ini:
                 ini.write("[foo]\n")
                 ini.write("hash_name=md5\n")
 
@@ -67,7 +67,7 @@ class TestConfig(BaseTestCase):
             result = self.invoke_cli("config", "--debug")
             self.assertIn("pyhardlinkbackup", result.output)
 
-            ini_path = os.path.join(os.getcwd(), "pyhardlinkbackup.ini")
+            ini_path = os.path.join(os.getcwd(), "PyHardLinkBackup.ini")
             self.assertIn(ini_path, result.output)
 
             self.assertIn("'hash_name': 'md5',", result.output)

--- a/pyhardlinkbackup/tests/test_config.py
+++ b/pyhardlinkbackup/tests/test_config.py
@@ -19,7 +19,7 @@ class TestConfig(BaseTestCase):
     def test_user_ini_default(self):
         runner = CliRunner()
         result = self.invoke_cli("config", "--debug")
-        self.assertIn("pyhardlinkbackup", result.output)
+        self.assertIn("PyHardLinkBackup v", result.output)
 
         # check if unittest temp PyHardLinkBackup.ini is used:
         self.assertIn(self.ini_path, result.output)
@@ -36,7 +36,7 @@ class TestConfig(BaseTestCase):
             phlb_config._load(force=True)
             result = self.invoke_cli("config", "--debug")
             self.assertIn(USER_INI_PATH, result.output)
-            self.assertIn("PyHardLinkBackup.sqlite3", result.output)
+            self.assertIn("PyHardLinkBackups.sqlite3", result.output)
 
     def test_default(self):
         os.remove(self.ini_path)  # remove unittests .ini
@@ -50,7 +50,7 @@ class TestConfig(BaseTestCase):
         self.assertTrue(os.path.isfile(USER_INI_PATH))
 
         # check the defaults:
-        self.assertIn("PyHardLinkBackup.sqlite3", result.output)
+        self.assertIn("PyHardLinkBackups.sqlite3", result.output)
 
     def test_overwrite(self):
         """
@@ -65,7 +65,7 @@ class TestConfig(BaseTestCase):
             phlb_config._load(force=True)
 
             result = self.invoke_cli("config", "--debug")
-            self.assertIn("pyhardlinkbackup", result.output)
+            self.assertIn("PyHardLinkBackup v", result.output)
 
             ini_path = os.path.join(os.getcwd(), "PyHardLinkBackup.ini")
             self.assertIn(ini_path, result.output)

--- a/pyhardlinkbackup/tests/test_config.py
+++ b/pyhardlinkbackup/tests/test_config.py
@@ -36,7 +36,7 @@ class TestConfig(BaseTestCase):
             phlb_config._load(force=True)
             result = self.invoke_cli("config", "--debug")
             self.assertIn(USER_INI_PATH, result.output)
-            self.assertIn("pyhardlinkbackups.sqlite3", result.output)
+            self.assertIn("PyHardLinkBackup.sqlite3", result.output)
 
     def test_default(self):
         os.remove(self.ini_path)  # remove unittests .ini
@@ -50,7 +50,7 @@ class TestConfig(BaseTestCase):
         self.assertTrue(os.path.isfile(USER_INI_PATH))
 
         # check the defaults:
-        self.assertIn("pyhardlinkbackups.sqlite3", result.output)
+        self.assertIn("PyHardLinkBackup.sqlite3", result.output)
 
     def test_overwrite(self):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyhardlinkbackup"
-version = "0.12.0"
+version = "0.12.1"
 description = "HardLink/Deduplication Backups with Python"
 authors = ["JensDiemer <git@jensdiemer.de>"]
 keywords=['Backup', 'Hardlink', 'Windows', 'Linux']

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,9 +7,8 @@ testpaths = pyhardlinkbackup
 DJANGO_SETTINGS_MODULE = pyhardlinkbackup.django_project.settings
 addopts =
     # see full diff:
-    -vv
-
-    --verbose
+    #-vv
+    #--verbose
 
     --reuse-db
     --nomigrations


### PR DESCRIPTION
Mostly done in
https://github.com/jedie/PyHardLinkBackup/commit/9783541f583cd5d448607d7d4e2d6bc50a5dd063

Only the package name should be lower-cased.